### PR TITLE
Connectionstring fix

### DIFF
--- a/CasusZuydFitV0.1/DAL.cs
+++ b/CasusZuydFitV0.1/DAL.cs
@@ -6,8 +6,7 @@ namespace CasusZuydFitV0._1
 {
     public class DAL
     {
-        //private static readonly string dbConString = "Server=tcp:gabriellunesu.database.windows.net,1433;Initial Catalog=ZuydFitFinal;Persist Security Info=False;User ID=gabriellunesu;Password=3KmaCBt5nU4qZ4s%xG5@;MultipleActiveResultSets=False;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;";
-        private static readonly string dbConString = "data source = LUCAS; initial catalog = ZuydFitFinal; trusted_connection=true; MultipleActiveResultSets=true;";
+        private static readonly string dbConString = "Server=tcp:gabriellunesu.database.windows.net,1433;Initial Catalog=ZuydFitFinal;Persist Security Info=False;User ID=gabriellunesu;Password=3KmaCBt5nU4qZ4s%xG5@;MultipleActiveResultSets=True;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30;";
         public class UserDAL
         {
             public List<User> users = new List<User>();


### PR DESCRIPTION
"MultipleActiveResultSets=True", dit zorgt dat meerdere readers/sqlCommands tegelijk kunnen worden uitgevoerd, maar dit is eigenlijk geen oplossing voor het probleem van GetActivities(). Namelijk dat het te vaak using etc gebruikt, deze beter opslitsen maar voor nu werkt het 